### PR TITLE
Update HTTPS profile port to 5107

### DIFF
--- a/EasyTime.EndpointApi/Properties/launchSettings.json
+++ b/EasyTime.EndpointApi/Properties/launchSettings.json
@@ -24,7 +24,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:7026;http://localhost:5014",
+      "applicationUrl": "http://localhost:5107",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
## Summary
- set the HTTPS profile applicationUrl to use http://localhost:5107 so the API listens on the new default port

## Testing
- dotnet run --project EasyTime.EndpointApi *(fails: dotnet not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c84462a2cc83259fbae768a5b778c0